### PR TITLE
league/oauth2-client ~1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "league/oauth2-client": "1.1.*"
+        "league/oauth2-client": "~1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
To be more flexible with future versions used ~

According to [Composer Documentation](https://getcomposer.org/doc/articles/versions.md#tilde)
`~1.2` is equivalent to `>=1.2 <2.0.0`
